### PR TITLE
Update RunSqlScriptsAzure.ps1 to fix foreach bug

### DIFF
--- a/RunSqlScriptsAzure/RunSqlScriptsAzure.ps1
+++ b/RunSqlScriptsAzure/RunSqlScriptsAzure.ps1
@@ -46,10 +46,10 @@ Try
 	$SqlCmd.Connection = $SqlConnection
 	$SqlCmd.CommandTimeout = $queryTimeout
 
-	foreach ($f in Get-ChildItem -path "$pathToScripts" -Filter *.sql | sort-object)
+	foreach ($sqlScript in Get-ChildItem -path "$pathToScripts" -Filter *.sql | sort-object)
 	{	
 		#Execute the query
-		$Query = [IO.File]::ReadAllText("$sqlScript")
+		$Query = [IO.File]::ReadAllText("$($sqlScript.FullName)")
 		$SqlCmd.CommandText = $Query
 		$reader = $SqlCmd.ExecuteNonQuery()
 	}


### PR DESCRIPTION
The foreach was using $f as the variable but the inner code was using $sqlScript.  It also needs to look at the FullName of the $sqlScript to get the full path of the file.