### PR TITLE
Fixed granting rights to the newly created user

### DIFF
--- a/AddOrUpdateUserAzure/AddOrUpdateUserAzure.ps1
+++ b/AddOrUpdateUserAzure/AddOrUpdateUserAzure.ps1
@@ -21,7 +21,7 @@ Try
 	Write-Host "Running Stored Procedure"
 
 	#Construct to the SQL to run
-	[string]$sqlQuery = "IF NOT EXISTS (SELECT name FROM sys.database_principals WHERE name = N'$targetUserName') CREATE USER [$targetUserName] WITH PASSWORD = '$targetUserPassword' ELSE ALTER USER [$targetUserName] WITH PASSWORD = '$targetUserPassword' ; GRANT SELECT ON SCHEMA :: [dbo] TO $targetUserName"
+	[string]$sqlQuery = "IF NOT EXISTS (SELECT name FROM sys.database_principals WHERE name = N'$targetUserName') CREATE USER [$targetUserName] WITH PASSWORD = '$targetUserPassword' ELSE ALTER USER [$targetUserName] WITH PASSWORD = '$targetUserPassword' ; ALTER ROLE db_datareader ADD MEMBER [$targetUserName] ; ALTER ROLE db_datawriter ADD MEMBER [$targetUserName]"
 		
 	#Execute the query
 	$SqlConnection = New-Object System.Data.SqlClient.SqlConnection

--- a/AddOrUpdateUserAzure/task.json
+++ b/AddOrUpdateUserAzure/task.json
@@ -8,7 +8,7 @@
     "version": {
         "Major": "1",
         "Minor": "0",
-        "Patch": "0"
+        "Patch": "1"
     },
     "demands": ["azureps"],
     "minimumAgentVersion": "1.95.0",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "sql-toolkit-azure",
     "name": "SQL Toolkit for Azure",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "public": true,
     "publisher": "andrewlackenby",
 	"categories": [


### PR DESCRIPTION
Changed the just GRANT SELECT to role membership for datareader and datawriter. I believe this makes more sense when providing database scope access to, f.e., a single application